### PR TITLE
remove iteration_utitlities dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,8 +66,6 @@ Requirements
 
 * dask
 
-* iteration_utilities
-
 * xarray
 
 Credits

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -19,7 +19,6 @@ dependencies:
   - nbsphinx-link
   - ipython
   - nc-time-axis
-  - iteration_utilities
   - cftime
   - dask
 

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -9,7 +9,6 @@ dependencies:
     - setuptools
     - pooch
     - netCDF4
-    - iteration_utilities
     # for testing
     - pytest
     - pytest-cov

--- a/ci/requirements/requirements.txt
+++ b/ci/requirements/requirements.txt
@@ -1,6 +1,5 @@
 dask>=2021.9.1
 xarray>=0.19.0
-iteration_utilities>=0.11.0
 cftime
 netcdf4
 h5netcdf

--- a/pyhomogenize/_time_control.py
+++ b/pyhomogenize/_time_control.py
@@ -1,5 +1,6 @@
+from collections import Counter
+
 import xarray as xr
-from iteration_utilities import duplicates
 
 from . import _consts as consts
 from ._netcdf_basics import netcdf_basics
@@ -71,7 +72,8 @@ class time_control(netcdf_basics):
     def _duplicates(self):
         """Get duplicated time steps."""
         time = self._equalize_time(self.time, ignore=self.equalize)
-        return sorted(list(duplicates(time)))
+        counts = Counter(time)
+        return sorted([t for t, n in counts.items() if n > 1])
 
     def _missings(self):
         """Get missing time steps."""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -19,6 +19,3 @@ def _importskip(modname):
 has_dask, requires_dask = _importskip("dask")
 has_xarray, requires_xarray = _importskip("xarray")
 has_numpy, requires_numpy = _importskip("numpy")
-has_iteration_utilities, requires_iteration_utilities = _importskip(
-    "iteration_utilities"
-)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,11 +6,9 @@ import pytest
 import pyhomogenize as pyh
 
 from . import has_dask  # noqa
-from . import has_iteration_utilities  # noqa
 from . import has_numpy  # noqa
 from . import has_xarray  # noqa
 from . import requires_dask  # noqa
-from . import requires_iteration_utilities  # noqa
 from . import requires_numpy  # noqa
 from . import requires_xarray  # noqa
 

--- a/tests/test_netcdf_basics.py
+++ b/tests/test_netcdf_basics.py
@@ -6,11 +6,9 @@ import pytest
 import pyhomogenize as pyh
 
 from . import has_dask  # noqa
-from . import has_iteration_utilities  # noqa
 from . import has_numpy  # noqa
 from . import has_xarray  # noqa
 from . import requires_dask  # noqa
-from . import requires_iteration_utilities  # noqa
 from . import requires_numpy  # noqa
 from . import requires_xarray  # noqa
 

--- a/tests/test_time_control.py
+++ b/tests/test_time_control.py
@@ -6,11 +6,9 @@ import pytest
 import pyhomogenize as pyh
 
 from . import has_dask  # noqa
-from . import has_iteration_utilities  # noqa
 from . import has_numpy  # noqa
 from . import has_xarray  # noqa
 from . import requires_dask  # noqa
-from . import requires_iteration_utilities  # noqa
 from . import requires_numpy  # noqa
 from . import requires_xarray  # noqa
 


### PR DESCRIPTION
This pull request removes the dependency on the `iteration_utilities` package from the codebase and replaces its usage with Python's built-in `collections.Counter`. The change simplifies the project's dependencies and updates both the implementation and related configuration files accordingly.

**Dependency removal:**

* Removed `iteration_utilities` from all dependency files, including `requirements.txt`, `environment.yml`, `docs.yml`, and the `README.rst` requirements section. [[1]](diffhunk://#diff-755bcc1078a02e307c24b13db491819873ce3fffa41e126e1a95e019b95bda28L3) [[2]](diffhunk://#diff-9695ee29c655614afdb7cb65c0497bcad0041216005b87be5b6bf478626723acL12) [[3]](diffhunk://#diff-6d282d9694af8ca51bb56c8caea8acb9bfd9fd93c5eb69dc8dcc936f482307a6L22) [[4]](diffhunk://#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fL69-L70)

**Code refactoring:**

* Replaced the use of `iteration_utilities.duplicates` with a custom implementation using `collections.Counter` in the `_duplicates` method in `pyhomogenize/_time_control.py`. [[1]](diffhunk://#diff-02289ddf00b2e1ae3af9eeb6d2057a40a04c44774ff2504f5e3e40a4953e8df0R1-L2) [[2]](diffhunk://#diff-02289ddf00b2e1ae3af9eeb6d2057a40a04c44774ff2504f5e3e40a4953e8df0L74-R76)

**Test suite cleanup:**

* Removed import checks and requirements for `iteration_utilities` from the test initialization and test files, as the package is no longer used. [[1]](diffhunk://#diff-001e61d97d9dee27d0c5aa1f23ba6c1972cd8a2e8320bac839656b0ab935b84dL22-L24) [[2]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eL9-L13) [[3]](diffhunk://#diff-07de384e673516a12e005b36cf6e5a9289dc1e5aa3632f07565cc8695eaa0a71L9-L13) [[4]](diffhunk://#diff-7f39467e6606081b293c10f6eec01aca85860c114bfae447d62e2c798aa4c3faL9-L13)