### PR TITLE
Update Python versions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         # Bookend python versions
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.14"]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,10 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
     ],
     description="Tool to homogenize netCDF files to CF standard",
     entry_points={


### PR DESCRIPTION
This pull request updates the project's supported Python versions to include newer releases and remove older ones. The changes ensure that both the CI workflow and package metadata reflect support for Python 3.11, 3.12, 3.13, and 3.14, while dropping support for 3.9 and 3.10.

**Python version support updates:**

* Updated the CI workflow in `.github/workflows/ci.yml` to test against Python 3.11, 3.12, and 3.14, removing 3.9 and 3.10.
* Updated the `setup.py` classifiers to advertise support for Python 3.11, 3.12, 3.13, and 3.14, and removed references to 3.9 and 3.10.